### PR TITLE
Add PySCF orbital visualization

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -128,3 +128,21 @@ hr {
   background-color: #444;
   margin: 40px 0;
 }
+
+/* Orbital Grid */
+.orbital-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 15px;
+  margin-top: 20px;
+}
+
+.orbital-item img {
+  width: 100%;
+  border: 1px solid #444;
+  border-radius: 4px;
+}
+
+.orbital-item p {
+  margin-top: 5px;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ Flask==2.2.5
 flask-cors==3.0.10
 python-dotenv==1.0.0
 openai==0.27.0
+pyscf==2.5.0
+matplotlib==3.8.4


### PR DESCRIPTION
## Summary
- generate molecular orbital plots with PySCF on the backend
- serve new `/api/pyscf` endpoint
- display returned orbital images in a grid on the frontend
- add required dependencies

## Testing
- `python -m py_compile server.py`